### PR TITLE
Fleet gen improvements

### DIFF
--- a/src/agents/Ship.ts
+++ b/src/agents/Ship.ts
@@ -60,6 +60,6 @@ namespace Game {
     let spriteKey: string = spritePrefix + String(team);
     let sprite: Phaser.Sprite = game.add.sprite(x, y, spriteKey);
     sprite.scale.setTo(scale, scale);
-    return sprite
+    return sprite;
   }
 }

--- a/src/agents/Ship.ts
+++ b/src/agents/Ship.ts
@@ -8,6 +8,8 @@
 namespace Game {
   export interface IShipSubclass {
     new (game: Game, x: number, y: number, team: number): Ship;
+    getSupportGroups(): Array<ISupportGroup>;
+    RESOURCE_COST: number;
   }
 
   export interface ISupportGroup {
@@ -33,8 +35,9 @@ namespace Game {
       }
     }
 
-    public getSupportGroups(): Array<ISupportGroup> {
-      return [];
+    public getType(): IShipSubclass {
+      // Ship isn't a ship subclass, we'll never instantiate it directly
+      return null;
     }
   }
 }

--- a/src/agents/Ship.ts
+++ b/src/agents/Ship.ts
@@ -21,6 +21,21 @@ namespace Game {
   export class Ship extends PhysicsObject {
     public constructor(game: Game.Game, sprite: Phaser.Sprite, public state: State, public health: number, public team: number) {
       super(game, sprite, health);
+
+      // Super constructor enables body
+      // Set orientation based on team
+      let angle: number = 0;
+      switch (team) {
+        case 1:
+          angle = 90;
+          break;
+        case 2:
+          angle = -90;
+          break;
+        default: angle = 0;
+      }
+
+      this.sprite.body.angle = angle;
     }
 
     public update(): void {

--- a/src/agents/Ship.ts
+++ b/src/agents/Ship.ts
@@ -40,4 +40,9 @@ namespace Game {
       return null;
     }
   }
+
+  export function teamToShipSprite(game: Game.Game, x: number, y: number, spritePrefix: string, team: number): Phaser.Sprite {
+    let spriteKey: string = spritePrefix + String(team);
+    return game.add.sprite(x, y, spriteKey);
+  }
 }

--- a/src/agents/ships/Battleship.ts
+++ b/src/agents/ships/Battleship.ts
@@ -10,7 +10,7 @@ namespace Game {
     public static BATTLESHIP_BASE_HEALTH: number = 1000;
 
     public constructor(game: Game.Game, x: number, y: number, public team: number) {
-      super(game, teamToBattleshipSprite(game, x, y, team), new State(), Battleship.BATTLESHIP_BASE_HEALTH, team);
+      super(game, teamToShipSprite(game, x, y, "battleship_", team), new State(), Battleship.BATTLESHIP_BASE_HEALTH, team);
     }
 
     public getType(): IShipSubclass {
@@ -28,10 +28,5 @@ namespace Game {
         shipType: Cruiser
       }];
     }
-  }
-
-  function teamToBattleshipSprite(game: Game.Game, x: number, y: number, team: number): Phaser.Sprite {
-    let spriteKey: string = "battleship_" + team;
-    return game.add.sprite(x, y, spriteKey);
   }
 }

--- a/src/agents/ships/Battleship.ts
+++ b/src/agents/ships/Battleship.ts
@@ -13,7 +13,15 @@ namespace Game {
       super(game, teamToBattleshipSprite(game, x, y, team), new State(), Battleship.BATTLESHIP_BASE_HEALTH, team);
     }
 
-    public getSupportGroups(): Array<ISupportGroup> {
+    public getType(): IShipSubclass {
+      return Battleship;
+    }
+
+    ///// Static stuff used by fleet generation /////
+
+    public static RESOURCE_COST: number = 100;
+
+    public static getSupportGroups(): Array<ISupportGroup> {
       return [{
         maxDistance: 500,
         maxNumber: 3,

--- a/src/agents/ships/Cruiser.ts
+++ b/src/agents/ships/Cruiser.ts
@@ -13,7 +13,15 @@ namespace Game {
       super(game, teamToCruiserSprite(game, x, y, team), new State(), Cruiser.CRUISER_BASE_HEALTH, team);
     }
 
-    public getSupportGroups(): Array<ISupportGroup> {
+    public getType(): IShipSubclass {
+      return Cruiser;
+    }
+
+    ///// Static stuff used by fleet generation /////
+
+    public static RESOURCE_COST: number = 25;
+
+    public static getSupportGroups(): Array<ISupportGroup> {
       return [{
         maxDistance: 200,
         maxNumber: 10,

--- a/src/agents/ships/Cruiser.ts
+++ b/src/agents/ships/Cruiser.ts
@@ -10,7 +10,7 @@ namespace Game {
     public static CRUISER_BASE_HEALTH: number = 250;
 
     public constructor(game: Game.Game, x: number, y: number, public team: number) {
-      super(game, teamToCruiserSprite(game, x, y, team), new State(), Cruiser.CRUISER_BASE_HEALTH, team);
+      super(game, teamToShipSprite(game, x, y, "cruiser_", team), new State(), Cruiser.CRUISER_BASE_HEALTH, team);
     }
 
     public getType(): IShipSubclass {
@@ -28,10 +28,5 @@ namespace Game {
         shipType: Fighter
       }];
     }
-  }
-
-  function teamToCruiserSprite(game: Game.Game, x: number, y: number, team: number): Phaser.Sprite {
-    let spriteKey: string = "cruiser_" + team;
-    return game.add.sprite(x, y, spriteKey);
   }
 }

--- a/src/agents/ships/Fighter.ts
+++ b/src/agents/ships/Fighter.ts
@@ -10,7 +10,7 @@ namespace Game {
     public static FIGHTER_BASE_HEALTH: number = 50;
 
     public constructor(game: Game.Game, x: number, y: number, public team: number) {
-      super(game, teamToFighterSprite(game, x, y, team), new State(), Fighter.FIGHTER_BASE_HEALTH, team);
+      super(game, teamToShipSprite(game, x, y, "fighter_", team), new State(), Fighter.FIGHTER_BASE_HEALTH, team);
     }
 
     public getType(): IShipSubclass {
@@ -24,10 +24,5 @@ namespace Game {
     public static getSupportGroups(): Array<ISupportGroup> {
       return [];
     }
-  }
-
-  function teamToFighterSprite(game: Game.Game, x: number, y: number, team: number): Phaser.Sprite {
-    let spriteKey: string = "fighter_" + team;
-    return game.add.sprite(x, y, spriteKey);
   }
 }

--- a/src/agents/ships/Fighter.ts
+++ b/src/agents/ships/Fighter.ts
@@ -12,6 +12,18 @@ namespace Game {
     public constructor(game: Game.Game, x: number, y: number, public team: number) {
       super(game, teamToFighterSprite(game, x, y, team), new State(), Fighter.FIGHTER_BASE_HEALTH, team);
     }
+
+    public getType(): IShipSubclass {
+      return Fighter;
+    }
+
+    ///// Static stuff used by fleet generation /////
+
+    public static RESOURCE_COST: number = 5;
+
+    public static getSupportGroups(): Array<ISupportGroup> {
+      return [];
+    }
   }
 
   function teamToFighterSprite(game: Game.Game, x: number, y: number, team: number): Phaser.Sprite {

--- a/src/maps/FleetCompGenerator.ts
+++ b/src/maps/FleetCompGenerator.ts
@@ -31,14 +31,38 @@ namespace Game {
       let fleet: Array<Ship> = this.createGroup(centralBattleship);
 
       console.log(fleet);
+      console.log(this.getMaxGroupCost(centralBattleship.getType()));
 
       return fleet;
     }
 
+    /**
+     * Recursively calculate the maximum cost of a battle group
+     * for a given ship type, including itself.
+     */
+    private getMaxGroupCost(centralShipType: IShipSubclass): number {
+      let cost: number = centralShipType.RESOURCE_COST;
+      let supportGroups: Array<ISupportGroup> = centralShipType.getSupportGroups();
+      if (supportGroups.length === 0) {
+        return cost;
+      }
+
+      for (let i: number = 0; i < supportGroups.length; i++) {
+        cost += supportGroups[i].maxNumber * this.getMaxGroupCost(supportGroups[i].shipType);
+      }
+
+      return cost;
+    }
+
+    /**
+     * Place support ships around a central unit,
+     * and then recursively place support around each of those.
+     * Effectively builds a battle group out from a single unit.
+     */
     private createGroup(centralShip: Ship): Array<Ship> {
       // If there's no support for this ship type, return just this ship
       let fleet: Array<Ship> = [centralShip];
-      let supportGroups: Array<ISupportGroup> = centralShip.getSupportGroups();
+      let supportGroups: Array<ISupportGroup> = centralShip.getType().getSupportGroups();
       if (supportGroups.length === 0) {
         return fleet;
       }

--- a/src/maps/FleetCompGenerator.ts
+++ b/src/maps/FleetCompGenerator.ts
@@ -10,18 +10,13 @@ namespace Game {
     private params: IFleetCompParams;
     private resourcesRemaining: number;
 
-    private defaultParams: IFleetCompParams = {
-      resources: 500,
-      teamNumber: 2
-    };
-
     // These hold group cost information for each ship type.
     // Built on creation to save time during generation.
     private groupCosts: Map<IShipSubclass, number> = new Map<IShipSubclass, number>();
     private typesOrderedByCost: Array<IShipSubclass> = new Array<IShipSubclass>();
 
     public constructor(private game: Game, params?: IFleetCompParams) {
-      this.params = params || this.defaultParams;
+      this.params = params || this.getDefaultParams();
 
       // Build the group cost info, including a list of all types
       // in descending order by group cost
@@ -50,6 +45,17 @@ namespace Game {
       console.log(this.typesOrderedByCost);
     }
 
+    private getDefaultParams(): IFleetCompParams {
+      return {
+        maxX: this.game.world.bounds.width,
+        maxY: this.game.world.bounds.height,
+        minX: this.game.world.bounds.width / 2,
+        minY: 0,
+        resources: 500,
+        teamNumber: 2
+      };
+    }
+
     /**
      * Generates a fleet composition from the current params and returns it
      * as a list of ships (which should have positions), for now
@@ -63,8 +69,8 @@ namespace Game {
         let currentType: IShipSubclass = this.typesOrderedByCost[i];
 
         while (this.resourcesRemaining >= this.groupCosts.get(currentType)) {
-          let x: number = (i + 1) * 100;
-          let y: number = (i + 1) * 100;
+          let x: number = this.game.rnd.integerInRange(this.params.minX, this.params.maxX);
+          let y: number = this.game.rnd.integerInRange(this.params.minY, this.params.maxY);
           let centralShip: Ship = new currentType(this.game, x, y, this.params.teamNumber);
           fleet = fleet.concat(this.createGroup(centralShip));
         }

--- a/src/maps/IFleetCompParams.ts
+++ b/src/maps/IFleetCompParams.ts
@@ -10,5 +10,11 @@ namespace Game {
     // Any parameters go here, TBD
     resources: number;
     teamNumber: number;
+
+    // Defines the area to contain the fleet
+    minX: number;
+    minY: number;
+    maxX: number;
+    maxY: number;
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outFile": "dist/js/game.js"
+    "outFile": "dist/js/game.js",
+    "target": "es6"
   },
   "compileOnSave": true,
   "buildOnSave": true,


### PR DESCRIPTION
- Create fleet within a given area
- Don't go over the allotted resources
- Create groups (sorta naively) using the biggest central ship we can as long as we can, then go down by cost
- Scaled cruiser sprites down to 1.5
- Rotated ships to face the middle based on their team