### PR TITLE
Fixed target reselection

### DIFF
--- a/src/PhysicsObject.ts
+++ b/src/PhysicsObject.ts
@@ -55,9 +55,19 @@ namespace Game {
       if (otherThing.health < this.health) {
         this.health -= otherThing.health;
         otherThing.die();
+
+        // If we dropped below 0, die
+        if (this.health <= 0) {
+          this.die();
+        }
       } else if (this.health < otherThing.health) {
         otherThing.health -= this.health;
         this.die();
+
+        // If we dropped below 0, die
+        if (otherThing.health <= 0) {
+          otherThing.die();
+        }
       } else {
         // If both healths are equal, kill both
         otherThing.die();
@@ -67,9 +77,10 @@ namespace Game {
 
     public die(): void {
       // Do stuff
-      if (this == null || this.body == null || this.body.sprite == null) {
+      if (this.body == null || this.body.sprite == null) {
         return;
       }
+      this.health = 0;
       this.body.sprite.destroy();
     }
   }

--- a/src/agents/Ship.ts
+++ b/src/agents/Ship.ts
@@ -28,6 +28,9 @@ namespace Game {
     // TODO: determine a good value for this.
     public fireDelay: number = 1;
     private lastFireTime: number;
+
+    public target: Ship;
+
     public constructor(game: Game.Game, sprite: Phaser.Sprite, public state: State, public health: number, public team: number) {
       super(game, sprite, health);
       this.lastFireTime = game.time.totalElapsedSeconds();

--- a/src/agents/states/ChaseAndShoot.ts
+++ b/src/agents/states/ChaseAndShoot.ts
@@ -7,31 +7,30 @@
 
 namespace Game {
   export class ChaseAndShoot extends State {
-    private target: Ship = null;
-    public update(ship: Ship): State {
-      if (this.target == null || this.target.health <= 0) {
+    public update(agent: Ship): State {
+      if (!agent.target || agent.target.health <= 0) {
         // select a new target
         // TODO
-        this.target = null;
+        agent.target = null;
         if (Battle.CurrentBattle != null) {
           let enemies: Array<Game.Ship> = Battle.CurrentBattle.enemies;
-          let isAlly: boolean = ship.team === Battle.CurrentBattle.allies[0].team;
+          let isAlly: boolean = agent.team === Battle.CurrentBattle.allies[0].team;
           if (!isAlly) {
             enemies = Battle.CurrentBattle.allies;
           }
-          let enemiesSorted: Array<Game.Ship> = enemies.sort((e1, e2) => shipDist(e1, ship) - shipDist(e2, ship));
+          let enemiesSorted: Array<Game.Ship> = enemies.sort((e1, e2) => shipDist(e1, agent) - shipDist(e2, agent));
           for (let enemy of enemiesSorted) {
             if (enemy != null && enemy.health > 0) {
-              this.target = enemy;
+              agent.target = enemy;
               break;
             }
           }
         }
       }
-      if (this.target != null) {
-        ship.turnTowards(this.target);
-        ship.thrust(ship.maxThrustSpeed);
-        ship.fire();
+      if (agent.target != null) {
+        agent.turnTowards(agent.target);
+        agent.thrust(agent.maxThrustSpeed);
+        agent.fire();
       }
       return this;
     }

--- a/src/util.ts
+++ b/src/util.ts
@@ -28,10 +28,18 @@ namespace Game {
   }
 
   export function shipDist(ship1: Ship, ship2: Ship): number {
+    // If either ship is dead, return INFINITY
+    if (!ship1 || ship1.health < 0 || !ship1.sprite || !ship1.sprite.body) {
+      return Number.POSITIVE_INFINITY;
+    }
+    if (!ship2 || ship2.health < 0 || !ship2.sprite || !ship2.sprite.body) {
+      return Number.POSITIVE_INFINITY;
+    }
+
     let s1X: number = ship1.sprite.body.x;
     let s1Y: number = ship1.sprite.body.y;
-    let s2X: number  = ship2.sprite.body.x;
-    let s2Y: number  = ship2.sprite.body.y;
+    let s2X: number = ship2.sprite.body.x;
+    let s2Y: number = ship2.sprite.body.y;
     let dx: number = s1X - s2X;
     let dy: number = s1Y - s2Y;
     return Math.sqrt(dx ** 2 + dy ** 2);


### PR DESCRIPTION
The main underlying problem was that ship HP weren't going to 0 when they died, according to console logging.  Fixed by making absolutely sure that when health hits 0, die() is called, and vice versa.  As well as some small cleanup.